### PR TITLE
Allow multiple methods on dbus-proxy configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,13 @@ is to consider anything connecting to the bus specified when starting dbus-proxy
 as being on the 'inside' and thus any interaction with the bus specified when
 starting dbus-proxy is 'outgoing'.
 
-When a D-Bus message is sent, the `dbus-proxy` compares message's direction, interface, path and method with
-configuration list. if a matching rule is found, the message is allowed to forward and otherwise it is dropped.
+A note on 'method' in the configuration:
+Method can be either a string or list of strings. This behavior is useful when user wants from proxy
+to use many methods but not all of them.
+
+When a D-Bus message is sent, the `dbus-proxy` compares message's direction, interface, path and method
+with configuration list. if a matching rule is found, the message is allowed to forward and otherwise it
+is dropped.
 
 
 A word on eavesdropping connections


### PR DESCRIPTION
Allow an array of methods to be entered to configuration
This didn't effect previous behavior, meaning previous behavior is still exist.