### PR TITLE
Bump cookbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,11 @@
 *.swp
 *.swo
 build
+
+.vagrant/
+component-test/__pycache__/
+component-test/component-test-results.xml
+component-test/conftest.pyc
+component-test/service_stubs.pyc
+ubuntu-*-console.log
+


### PR DESCRIPTION
Update Vagrantfile based on cookbook updates
Switch to Ubuntu xenial64 to match upstream projects and make maintenance easier
Add .gitignore for various artifact files.

Signed-off-by: Oscar Andreasson <oscar.andreasson@pelagicore.com>